### PR TITLE
Updates to naming convention and code fixes

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -27,16 +27,6 @@ class Auth {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
   }
-
-  /**
-   * Test authentication and return error to client
-   * @param  {String}   clientId      API_KEY provided by client
-   * @param  {String}   clientSecret  API_SECRET provided by client
-   */
-  testAuth(clientId: string, clientSecret: string) {
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
-  }
 }
 
 export let auth = new Auth();

--- a/src/lib/httpsClient.ts
+++ b/src/lib/httpsClient.ts
@@ -31,4 +31,4 @@ class HttpsClient {
   }
 }
 
-export let httpsClient = new HttpsClient();
+export const httpsClient = new HttpsClient();

--- a/src/lib/paypay-rest-sdk.ts
+++ b/src/lib/paypay-rest-sdk.ts
@@ -10,7 +10,7 @@ import { httpsClient } from './httpsClient';
 import CryptoJS from 'crypto-js';
 import { v4 as uuidv4 } from 'uuid';
 
-interface httpsClientMessage {
+interface HttpsClientMessage {
   (message: string): void;
 }
 
@@ -100,7 +100,7 @@ class PayPayRestSDK {
    * @returns {Object}        Returns result containing STATUS and BODY
    * @param {Object} payload  JSON object payload
    */
-  public qrCodeCreate(payload: any, callback: httpsClientMessage): void {
+  public qrCodeCreate(payload: any, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_PAYMENT', 'QRCODE_CREATE', payload), payload, (result: any) => {
       callback(result);
     });
@@ -112,7 +112,7 @@ class PayPayRestSDK {
    * @returns {Object}            Returns result containing STATUS and BODY
    * @param {string} inputParams  Array of codeId : QR Code that is to be deleted
    */
-  public qrCodeDelete(inputParams: Array<string | number>, callback: httpsClientMessage): void {
+  public qrCodeDelete(inputParams: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_PAYMENT', 'QRCODE_DELETE', inputParams), '', (result: any) => {
       callback(result);
     });
@@ -125,7 +125,7 @@ class PayPayRestSDK {
    * @returns {Object}            Returns result containing STATUS and BODY
    * @param {string} inputParams  Array of merchantPaymentId : The unique payment transaction id provided by merchant
    */
-  public getPaymentDetails(inputParams: Array<string | number>, callback: httpsClientMessage): void {
+  public getPaymentDetails(inputParams: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_PAYMENT', 'GET_PAYMENT_DETAILS', inputParams), '', (result: any) => {
       callback(result);
     });
@@ -139,7 +139,7 @@ class PayPayRestSDK {
    * @returns {Object}            Returns result containing STATUS and BODY
    * @param {string} inputParams  Array of merchantPaymentId : The unique payment transaction id provided by merchant
    */
-  public paymentCancel(inputParams: Array<string | number>, callback: httpsClientMessage): void {
+  public paymentCancel(inputParams: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_PAYMENT', 'CANCEL_PAYMENT', inputParams), '', (result: any) => {
       callback(result);
     });
@@ -153,7 +153,7 @@ class PayPayRestSDK {
    * @returns {Object}        Returns result containing STATUS and BODY
    * @param {Object} payload  JSON object payload
    */
-  public paymentAuthCapture(payload: Array<string | number>, callback: httpsClientMessage): void {
+  public paymentAuthCapture(payload: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_PAYMENT', 'PAYMENT_AUTH_CAPTURE', payload), payload.toString(), (result: any) => {
       callback(result);
     });
@@ -167,7 +167,7 @@ class PayPayRestSDK {
    * @returns {Object}        Returns result containing STATUS and BODY
    * @param {Object} payload  JSON object payload
    */
-  public paymentAuthRevert(payload: Array<string | number>, callback: httpsClientMessage): void {
+  public paymentAuthRevert(payload: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_PAYMENT', 'PAYMENT_AUTH_REVERT', payload), payload.toString(), (result: any) => {
       callback(result);
     });
@@ -180,7 +180,7 @@ class PayPayRestSDK {
    * @returns {Object}        Returns result containing STATUS and BODY
    * @param {Object} payload  JSON object payload
    */
-  public paymentRefund(payload: Array<string | number>, callback: httpsClientMessage): void {
+  public paymentRefund(payload: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_PAYMENT', 'REFUND_PAYMENT', payload), payload.toString(), (result: any) => {
       callback(result);
     });
@@ -193,7 +193,7 @@ class PayPayRestSDK {
    * @returns {Object}            Returns result containing STATUS and BODY
    * @param {string} inputParams  Array of merchantPaymentId : The unique payment transaction id provided by merchant
    */
-  public getRefundDetails(inputParams: Array<string | number>, callback: httpsClientMessage): void {
+  public getRefundDetails(inputParams: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_PAYMENT', 'GET_REFUND_DETAILS', inputParams), '', (result: any) => {
       callback(result);
     });
@@ -207,7 +207,7 @@ class PayPayRestSDK {
    * @returns {Object}           Returns result containing STATUS and BODY
    * @param {Array} inputParams  Array of userAuthorizationId, amount, currency, productType
    */
-  public checkUserWalletBalance(inputParams: Array<string | number>, callback: httpsClientMessage): void {
+  public checkUserWalletBalance(inputParams: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_WALLET', 'CHECK_BALANCE', inputParams), '', (result: any) => {
       callback(result);
     });
@@ -220,7 +220,7 @@ class PayPayRestSDK {
    * @returns {Object}           Returns result containing STATUS and BODY
    * @param {Array} inputParams  Array of apiKey, jwtToken
    */
-  public authorization(inputParams: Array<string | number>, callback: httpsClientMessage): void {
+  public authorization(inputParams: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_DIRECT_DEBIT', 'AUTHORIZATION', inputParams), '', (result: any) => {
       callback(result);
     });
@@ -233,7 +233,7 @@ class PayPayRestSDK {
    * @returns {Object}           Returns result containing STATUS and BODY
    * @param {Array} inputParams  Array of apiKey, jwtToken
    */
-  public authorizationResult(inputParams: Array<string | number>, callback: httpsClientMessage): void {
+  public authorizationResult(inputParams: Array<string | number>, callback: HttpsClientMessage): void {
     httpsClient.httpsCall(PayPayRestSDK.paypaySetupOptions('API_DIRECT_DEBIT', 'AUTHORIZATION_RESULT', inputParams), '', (result: any) => {
       callback(result);
     });


### PR DESCRIPTION
paypay-rest-sdk.ts - updated naming convention to Pascal case for classes and interfaces.
httpsClient.ts - export of HttpsClient have been set to const
auth,ts - testAuth function removed

Fix for #13