### PR TITLE
Remove millisecond for createAuthHeader epoc

### DIFF
--- a/src/lib/paypay-rest-sdk.ts
+++ b/src/lib/paypay-rest-sdk.ts
@@ -29,7 +29,7 @@ class PayPayRestSDK {
   }
 
   private static createAuthHeader = (method: string, resourceUrl: string, body: any, auth: any) => {
-    const epoch = Date.now();
+    const epoch =  Math.floor(Date.now()/1000);
     const nonce	= uuidv4();
 
     let contentType = 'application/json';


### PR DESCRIPTION
In document, `epoc` time need seconds. 
https://www.paypay.ne.jp/opa/doc/jp/v1.0/webcashier#section/Authentication

But `Date.now()` got milliseconds. 
I think it's seems need remove mills.
see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Get_the_number_of_seconds_since_the_ECMAScript_Epoch