### PR TITLE
Remove project option for "tsconfig.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/paypay/paypayopa-sdk-node.git"
   },
   "scripts": {
-    "tsc": "tsc -p tsconfig.json",
+    "tsc": "tsc",
     "prepublish": "npm run tsc",
     "test": "test",
     "clean": "rm -rf ./.nyc_output ./node_modules/.cache ./coverage",


### PR DESCRIPTION
As explained in the [Handbook, Typescript](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#using-tsconfigjson-or-jsconfigjson), you don't need to specify the `tsconfig.json` file.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
