### PR TITLE
Change npm prepublish to prepublishOnly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
         node-version: '12.x'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
-    - run: npm run prepublish
     - run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -13,7 +13,6 @@ jobs:
         node-version: '12.x'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
-    - run: npm run prepublish
     - run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "git+https://github.com/paypay/paypayopa-sdk-node.git"
   },
   "scripts": {
-    "tsc": "tsc",
-    "prepublish": "npm run tsc",
+    "build": "tsc",
+    "prepublishOnly": "npm run build",
     "test": "jest",
     "clean": "rm -rf ./.nyc_output ./node_modules/.cache ./coverage",
     "lint": "eslint --ext .js,.jsx,.ts .",


### PR DESCRIPTION
1. As of npm 4 `prepublish` is deprecated (it is replaced by `prepublishOnly` and `prepare`, see [here](https://docs.npmjs.com/misc/scripts#prepublish-and-prepare)). `prepublishOnly` can be omitted from the publish pipeline, as it is "Run BEFORE the package is prepared and packed, ONLY on npm publish" ([source](https://docs.npmjs.com/misc/scripts)).

2. Change `tsc` script to `build`

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
