### PR TITLE
Fix error when optional merchant ID is not referenced

### DIFF
--- a/src/lib/paypay-rest-sdk.ts
+++ b/src/lib/paypay-rest-sdk.ts
@@ -67,12 +67,18 @@ class PayPayRestSDK {
   }
 
   private setHttpsOptions(header: string) {
+    let isempty : any = [undefined, null, "", 'undefined', 'null'];
     this.options.hostname = this.config.getHostname(),
     this.options.port = this.config.getPortNumber(),
     this.options.headers = {
         "Authorization": header,
         "X-ASSUME-MERCHANT": auth.merchantId,
       };
+    if(isempty.includes(auth.merchantId)){
+      this.options.headers = {
+        "Authorization": header,
+      };
+    }
    this.config.setHttpsOptions(this.options);
   }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](../blob/master/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

When we use the Node sdk, it say that the Merchant ID is optional if the user have only one merchant, but it's not the case, when the merchant ID is not referenced, an error occurs. This PR make the merchant ID really optional.

I'm not familiar yet with the project, so please, let me know if the modification fits the project conventions.