### PR TITLE
Fix error when optional merchant ID is not referenced

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,7 +7,7 @@
 class Auth {
   clientId: string;
   clientSecret: string;
-  merchantId: string;
+  merchantId?: string;
   /**
    * Set intial values to empty string
    */
@@ -25,8 +25,7 @@ class Auth {
   setAuth(clientId: string, clientSecret: string, merchantId?: string) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
-    if(merchantId!=undefined)
-      this.merchantId = merchantId;
+    this.merchantId = merchantId;
   }
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -22,10 +22,11 @@ class Auth {
    * @param  {String}   clientId      API_KEY provided by client
    * @param  {String}   clientSecret  API_SECRET provided by client
    */
-  setAuth(clientId: string, clientSecret: string, merchantId: string) {
+  setAuth(clientId: string, clientSecret: string, merchantId?: string) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
-    this.merchantId = merchantId;
+    if(merchantId!=undefined)
+      this.merchantId = merchantId;
   }
 }
 

--- a/src/lib/paypay-rest-sdk.ts
+++ b/src/lib/paypay-rest-sdk.ts
@@ -28,7 +28,7 @@ class PayPayRestSDK {
    * @param {string}  merchantId    MERCHANT_ID provided by end-user
    */
   public configure = (clientConfig: { clientId: string; clientSecret: string; merchantId?: string; productionMode: boolean;}) => {
-    auth.setAuth(clientConfig.clientId, clientConfig.clientSecret);
+    auth.setAuth(clientConfig.clientId, clientConfig.clientSecret,clientConfig.merchantId);
     if (clientConfig.productionMode) {
       this.productionMode = clientConfig.productionMode
     } else {

--- a/src/lib/paypay-rest-sdk.ts
+++ b/src/lib/paypay-rest-sdk.ts
@@ -27,8 +27,8 @@ class PayPayRestSDK {
    * @param {string}  clientSecret  API_SECRET provided by end-user
    * @param {string}  merchantId    MERCHANT_ID provided by end-user
    */
-  public configure = (clientConfig: { clientId: string; clientSecret: string; merchantId: string; productionMode: boolean;}) => {
-    auth.setAuth(clientConfig.clientId, clientConfig.clientSecret, clientConfig.merchantId);
+  public configure = (clientConfig: { clientId: string; clientSecret: string; merchantId?: string; productionMode: boolean;}) => {
+    auth.setAuth(clientConfig.clientId, clientConfig.clientSecret);
     if (clientConfig.productionMode) {
       this.productionMode = clientConfig.productionMode
     } else {
@@ -67,12 +67,18 @@ class PayPayRestSDK {
   }
 
   private setHttpsOptions(header: string) {
+    let isempty : any = [undefined, null, "", 'undefined', 'null'];
     this.options.hostname = this.config.getHostname(),
     this.options.port = this.config.getPortNumber(),
     this.options.headers = {
         "Authorization": header,
         "X-ASSUME-MERCHANT": auth.merchantId,
       };
+    if(isempty.includes(auth.merchantId)){
+      this.options.headers = {
+        "Authorization": header,
+      };
+    }
    this.config.setHttpsOptions(this.options);
   }
 

--- a/src/lib/paypay-rest-sdk.ts
+++ b/src/lib/paypay-rest-sdk.ts
@@ -28,7 +28,7 @@ class PayPayRestSDK {
    * @param {string}  merchantId    MERCHANT_ID provided by end-user
    */
   public configure = (clientConfig: { clientId: string; clientSecret: string; merchantId?: string; productionMode: boolean;}) => {
-    auth.setAuth(clientConfig.clientId, clientConfig.clientSecret,clientConfig.merchantId);
+    auth.setAuth(clientConfig.clientId, clientConfig.clientSecret, clientConfig.merchantId);
     if (clientConfig.productionMode) {
       this.productionMode = clientConfig.productionMode
     } else {

--- a/test/qrCodeCreateWithMerchantNotSpecified.test.ts
+++ b/test/qrCodeCreateWithMerchantNotSpecified.test.ts
@@ -1,0 +1,79 @@
+import { payPayRestSDK } from "../src/lib/paypay-rest-sdk";
+import { httpsClient } from '../src/lib/httpsClient';
+
+const conf = {
+    clientId: '5345435fsdfsr54353454',
+    clientSecret: 'dgfgdfgt46435gsdr35tte5',
+    productionMode: false
+};
+
+payPayRestSDK.configure(conf);
+
+test('Unit Test - Create QR code without specifying the merchant id', async () => {
+
+    const payload = {
+        merchantPaymentId: '2312324',
+        amount: {
+            amount: 1,
+            currency: 'JPY',
+        },
+        codeType: 'ORDER_QR',
+        orderDescription: 'Test Description',
+        isAuthorization: false,
+        redirectUrl: 'https://test.redirect.url/',
+        redirectType: 'WEB_LINK',
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1'
+    };
+
+    const response = {
+        "resultInfo": {
+            "code": "SUCCESS",
+            "message": "Success",
+            "codeId": "08100001"
+        },
+        "data": {
+            "codeId": "08100001",
+            "url": "https://test.url/",
+            "deeplink": "https://test.deeplink",
+            "expiryDate": 3213232,
+            "merchantPaymentId": "342423423",
+            "amount": {
+                "amount": 10.50,
+                "currency": "JPY"
+            },
+            "orderDescription": "Test Description",
+            "orderItems": [
+                {
+                    "name": "Test Item",
+                    "category": "Test Category",
+                    "quantity": 1,
+                    "productId": "349329",
+                    "unit_price": {
+                        "amount": 10.50,
+                        "currency": "JPY"
+                    }
+                }
+            ],
+            "metadata": {},
+            "requestedAt": 2131312,
+            "redirectUrl": "https://test.redirect.url/",
+            "redirectType": "WEB_LINK",
+            "isAuthorization": true,
+            "authorizationExpiry": null
+        }
+    };
+
+    const mockHttpsCall = jest.spyOn(httpsClient, 'httpsCall');
+    mockHttpsCall.mockImplementation(jest.fn((_options: any, _payload = '', _callback: any) => {
+        _callback(response);
+    }));
+
+    await payPayRestSDK.qrCodeCreate(payload, (result: any) => {
+        expect(result).toEqual(response);
+    });
+
+    expect(mockHttpsCall).toHaveBeenCalledTimes(1);
+    expect(mockHttpsCall).toHaveBeenCalledWith(expect.anything(), payload, expect.anything());
+
+    mockHttpsCall.mockClear();
+});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](../blob/master/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

When we use the Node sdk, it say that the Merchant ID is optional if the user have only one merchant, but it's not the case, when the merchant ID is not referenced, an error occurs. This PR make the merchant ID really optional.

I'm not familiar yet with the project, so please, let me know if the modification fits the project conventions.