### PR TITLE
Remove use of set-env in GitHub actions

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -8,12 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set version variable
-      id: vars
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Update version
       run: |
-        echo "RELEASE_VERSION=$RELEASE_VERSION"
-        sed -i -E "s/\\\"version\\\": \\\"0\.0\.0\\\",/\\\"version\\\": \\\"$RELEASE_VERSION\\\",/g" ./package.json
+        sed -i -E "s/\\\"version\\\": \\\"0\.0\.0\\\",/\\\"version\\\": \\\"${{ env.RELEASE_VERSION }}\\\",/g" ./package.json
     # Setup .npmrc file to publish to npm
     - uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Based on the PR done on python sdk :
https://github.com/paypay/paypayopa-sdk-python/pull/34

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
