### PR TITLE
Separate workflows using secrets from CI

### DIFF
--- a/.github/workflows/build-ci-target.yml
+++ b/.github/workflows/build-ci-target.yml
@@ -1,0 +1,30 @@
+name: PayPay Node SDK Upload CI Results
+on:
+  workflow_run:
+    workflows: ["Paypay Node SDK CI"]
+    types: ["completed"]
+jobs:
+  upload-codeclimate:
+    runs-on: ubuntu-latest
+    steps:
+    - name: codeclimate before-build
+      env: 
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID}}
+      run: |
+           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+           chmod +x ./cc-test-reporter
+           ./cc-test-reporter before-build
+
+    - name: Download coverage from CI run
+      uses: actions/download-artifact@v2
+      with:
+        name: coverage-lcov-14.x.info
+        path: artifacts/
+
+    - name: Show structure
+      run: ls -R
+
+    - name: codeclimate after-build
+      env: 
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID}}
+      run: ./cc-test-reporter after-build artifacts/lcov.info --exit-code 0

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -3,8 +3,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID}}
     strategy:
       matrix:
         node-version: [14.x, 12.x, 10.x]
@@ -28,11 +26,6 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: register repo token
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: |
-        echo repo_token: ${COVERALLS_REPO_TOKEN} > ./.coveralls.yml
     - run: npm install
     - run: npm run build --if-present
     - run: npm test
@@ -40,12 +33,12 @@ jobs:
       run: yarn coveralls
       continue-on-error: true
 
-    - name: Before script
-      run: |
-           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-           chmod +x ./cc-test-reporter
-           ./cc-test-reporter before-build           
-    
+    - name: Upload coverage GitHub artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-lcov-${{ matrix.node-version }}.info
+        path: ./coverage/lcov.info
+
     - name: Upload coverall reports
       uses: coverallsapp/github-action@master
       with:
@@ -54,6 +47,3 @@ jobs:
 
     - name: Upload to CoPilot
       run: bash <(curl -s https://copilot.blackducksoftware.com/ci/githubactions/scripts/upload)
-
-    - name: After build
-      run: ./cc-test-reporter after-build --exit-code 0


### PR DESCRIPTION
The CodeClimate uploading process requires access to secrets, which cannot be accessed in regular CI workflow runs for PRs that come from forks/bots.

A [GitHub blog post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)  suggests using the `workflow_run` trigger, and downloading artifacts to avoid running untrusted code while secrets are available.

N.B.: `workflow_run` workflows won't trigger on this PR, as they only run based on what workflows are present in the base branch (`master`), so this PR is expected to not get results for codeclimate-coverage statuses. 

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](../blob/master/contributing.md) document?
* [ ] Have you read and signed the automated Contributor's License Agreement?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
